### PR TITLE
Pin versions for streamlit, torch, and torchvision

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-streamlit
-torch
-torchvision
+streamlit==1.46.1
+torch==2.7.1
+torchvision==0.22.1
 Pillow


### PR DESCRIPTION
Specified exact versions for streamlit, torch, and torchvision in requirements.txt to ensure consistent dependency management. Pillow remains unpinned.